### PR TITLE
Updated Swime for Swift 5.0 support in podspec

### DIFF
--- a/GetStream.podspec
+++ b/GetStream.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
     ss.dependency "Moya", "12.0.1"
     ss.dependency "Alamofire", "4.8.1"
     ss.dependency "Result", "4.1"
-    ss.dependency "Swime", "3.0.1"
+    ss.dependency "Swime", "~> 3.0"
   end
   
   s.subspec "Faye" do |ss|


### PR DESCRIPTION
Using Cocoapods, Swime was not being able to be built using Swift 5.0.