### PR TITLE
Prefer using current instance of `Client` instead of `Client.shared` within an extension function.

### DIFF
--- a/Sources/Core/User/Client+User.swift
+++ b/Sources/Core/User/Client+User.swift
@@ -70,13 +70,13 @@ extension Client {
     /// - Returns: an object to cancel the request.
     @discardableResult
     public func createCurrentUser(completion: UserCompletion<User>? = nil) -> Cancellable {
-        guard let currentUserId = Client.shared.currentUserId else {
+        guard let currentUserId = currentUserId else {
             completion?(.failure(.parameterInvalid(\Client.currentUserId)))
             return SimpleCancellable()
         }
         
-        return create(user: User(id: currentUserId)) { result in
-            Client.shared.currentUser = try? result.get()
+        return create(user: User(id: currentUserId)) { [weak self] result in
+            self?.currentUser = try? result.get()
             
             if let completion = completion {
                 completion(result)


### PR DESCRIPTION
Fixes an issue where any instance of `Client` will reference the `shared` Client's `currentUserId` property when attempting to create the current user.

Please let me know if you'd like anything else changed!