### PR TITLE
Fix inaccessible error for clients using Comments

### DIFF
--- a/Sources/Core/Reactions/ReactionExtraDataProtocol.swift
+++ b/Sources/Core/Reactions/ReactionExtraDataProtocol.swift
@@ -23,7 +23,7 @@ public struct EmptyReactionExtraData: ReactionExtraDataProtocol, Equatable {
 
 /// Comment reaction extra data.
 public struct Comment: ReactionExtraDataProtocol {
-    let text: String
+    public let text: String
 }
 
 // MARK: - Like/Repost/Comment


### PR DESCRIPTION
Clients using a Comment are unable to access the underlying text value due to a 'text' is inaccessible due to 'internal' protection level error. Fix by making this public.
