### PR TITLE
Update AuthorizationMoyaPlugin.swift

### DIFF
--- a/Sources/Core/Moya/AuthorizationMoyaPlugin.swift
+++ b/Sources/Core/Moya/AuthorizationMoyaPlugin.swift
@@ -17,6 +17,7 @@ final class AuthorizationMoyaPlugin: PluginType {
     }
     
     func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
+        let token = self.token
         if token.isEmpty {
             return request
         }


### PR DESCRIPTION
fix crash due to token race condition in AuthorizationMoyaPlugin

# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Following the suggestion to create a PR related to this [bug issue](https://github.com/GetStream/swift-activity-feed/issues/19#issue-1032143324) submitted by @angelolloqui

> We are getting several crashes on production from the class AuthorizationMoyaPlugin in GetStream library.
> The crash report is:
> [...]
> It seems the token variable is not correct when setting this value in the request.
> I am checking the code and I do not see any wrong thing, except that token is an instance variable that might change and produce a race condition between the if token.isEmpty and the actual usage. Not sure if it helps, but maybe rewriting it to this would protect it: [...]
