### PR TITLE
Fix broken and uncompilable GetStream with starscream 4.0.x

### DIFF
--- a/Faye/Client.swift
+++ b/Faye/Client.swift
@@ -187,6 +187,9 @@ extension Client: WebSocketDelegate {
             isWebSocketConnected = false
             log("❌ WS Disconnect with error: \(error)")
             //handleError(error)
+        case .peerClosed:
+            isWebSocketConnected = false
+            log("❌ WS Disconnect: Connection closed")
         }
     }
 }

--- a/Faye/Client.swift
+++ b/Faye/Client.swift
@@ -141,7 +141,7 @@ extension Client {
 // MARK: - Connection
 
 extension Client: WebSocketDelegate {
-    public func didReceive(event: WebSocketEvent, client: WebSocket) {
+    public func didReceive(event: WebSocketEvent, client: WebSocketClient) {
         switch event {
         case .connected(let headers):
             isWebSocketConnected = true


### PR DESCRIPTION
# Submit a pull request

This pull request addresses an issue, where it has become non-functional due to recent changes in the Starscream library. Specifically, the Starscream library's 4.0.x (4.0.5 & 4.0.6) version update introduced a new enum case called `case peerClosed` in `WebSocketEvent` enum class [(details here)](https://github.com/daltoniam/Starscream/commit/f900d67759cdd11df3dcca34af21f40f59fe4e79#diff-2e4514a7ad13578f9c9cf7eb587e1ac4f93726c89e6e24fccc416b12deb24f0fR52) and has broken the conformance of the Client object to the `WebSocketDelegate` protocol, leaving the project uncompilable.

Build Error Encountered:
> -> Type 'Client' does not conform to protocol 'WebSocketDelegate'
> -> Switch must be exhaustive

A screenshot of the encountered error is shown below:

![Screenshot 2023-08-21 at 15 04 33](https://github.com/GetStream/stream-swift/assets/37219076/0bf1221f-5116-4713-bcb6-dcfbb246852f)

The issue originates from the fact that GetStream has been set up to track the latest changes to the major version of Starscream through its Package.swift file:
[Package.swift](https://github.com/GetStream/stream-swift/blob/2e3f45bf49b80573ea32322d6d80b1a52a4eb64b/Package.swift#L17)

The proposed solution in this pull request involves incorporating the new `WebSocketEvent.peerClosed` enum case and updating the delegate method inputs to receive an abstraction of WebSocket, consistent with the WebSocketClient definition.

The resolved state without errors is depicted in the screenshot below:

<img width="1512" alt="Screenshot 2023-08-21 at 15 40 54" src="https://github.com/mohamadrezakoohkan/stream-swift/assets/37219076/8781435e-49f4-40ca-8fda-9f1358f60882">

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) with my github username (required). 
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

